### PR TITLE
Update my.cnf to work with current MariaDB versions

### DIFF
--- a/native/Linux/etc/my.cnf.d/relution.cnf.template
+++ b/native/Linux/etc/my.cnf.d/relution.cnf.template
@@ -2,6 +2,9 @@
 collation-server=utf8mb4_general_ci
 character-set-server=utf8mb4
 max_allowed_packet=1G
-innodb_large_prefix=on
-innodb_file_format=Barracuda
 innodb_file_per_table=1
+
+## No longer needed/supported for MariaDB >= 10.2.2
+## If you have an older version please update or enable this
+# innodb_large_prefix=on
+# innodb_file_format=Barracuda


### PR DESCRIPTION
The `innodb_large_prefix` and `innodb_file_format` values are no longer
needed since they are now the default (since MariaDB 10.2.2). If those
values are present MariaDB fails to start.