### PR TITLE
Replace typographic quotation mark with ASCII character

### DIFF
--- a/native/Linux/etc/nginx/conf.d/relution-ssl.conf.template
+++ b/native/Linux/etc/nginx/conf.d/relution-ssl.conf.template
@@ -1,6 +1,6 @@
 log_format relution '$remote_addr - $remote_user [$time_local] '
             '"$request" $status $body_bytes_sent '
-            '"$http_referer" "$http_user_agent” "$http_x_forwarded_for" '
+            '"$http_referer" "$http_user_agent" "$http_x_forwarded_for" '
             '$request_time $upstream_response_time $pipe';
 
 map $http_upgrade $connection_upgrade {

--- a/native/Linux/etc/nginx/conf.d/relution.conf.template
+++ b/native/Linux/etc/nginx/conf.d/relution.conf.template
@@ -1,6 +1,6 @@
 log_format relution '$remote_addr - $remote_user [$time_local] '
             '"$request" $status $body_bytes_sent '
-            '"$http_referer" "$http_user_agent” "$http_x_forwarded_for" '
+            '"$http_referer" "$http_user_agent" "$http_x_forwarded_for" '
             '$request_time $upstream_response_time $pipe';
 
 map $http_upgrade $connection_upgrade {

--- a/native/WindowsServer/Program Files/nginx/conf.d/relution-ssl.conf.template
+++ b/native/WindowsServer/Program Files/nginx/conf.d/relution-ssl.conf.template
@@ -1,6 +1,6 @@
 log_format relution '$remote_addr - $remote_user [$time_local] '
             '"$request" $status $body_bytes_sent '
-            '"$http_referer" "$http_user_agent” "$http_x_forwarded_for" '
+            '"$http_referer" "$http_user_agent" "$http_x_forwarded_for" '
             '$request_time $upstream_response_time $pipe';
 
 map $http_upgrade $connection_upgrade {

--- a/native/WindowsServer/Program Files/nginx/conf.d/relution.conf.template
+++ b/native/WindowsServer/Program Files/nginx/conf.d/relution.conf.template
@@ -1,6 +1,6 @@
 log_format relution '$remote_addr - $remote_user [$time_local] '
             '"$request" $status $body_bytes_sent '
-            '"$http_referer" "$http_user_agent” "$http_x_forwarded_for" '
+            '"$http_referer" "$http_user_agent" "$http_x_forwarded_for" '
             '$request_time $upstream_response_time $pipe';
 
 map $http_upgrade $connection_upgrade {


### PR DESCRIPTION
Replace the typographic quotation mark with a plain (ASCII) quotation
mark since UTF-8 characters can cause issues on some systems.