### PR TITLE
Add database configuration to docker-compose.yml

### DIFF
--- a/docker/Linux/opt/relution/docker-compose.yml
+++ b/docker/Linux/opt/relution/docker-compose.yml
@@ -17,6 +17,7 @@ services:
       - '3306'
     volumes:
       - 'mariadb:/var/lib/mysql'
+      - '/opt/relution/relution.cnf:/etc/mysql/conf.d/relution.cnf'
   mongodb:
     image: mongo:latest
     restart: always

--- a/docker/Linux/opt/relution/relution.cnf
+++ b/docker/Linux/opt/relution/relution.cnf
@@ -1,0 +1,10 @@
+[mysqld]
+collation-server=utf8mb4_general_ci
+character-set-server=utf8mb4
+max_allowed_packet=1G
+innodb_file_per_table=1
+
+## No longer needed/supported for MariaDB >= 10.2.2
+## If you have an older version please update or enable this
+# innodb_large_prefix=on
+# innodb_file_format=Barracuda

--- a/docker/WindowsServer/Program Files/Relution/docker-compose.yml
+++ b/docker/WindowsServer/Program Files/Relution/docker-compose.yml
@@ -17,6 +17,7 @@ services:
       - '3306'
     volumes:
       - 'mariadb:/var/lib/mysql'
+      - 'C:\Program Files\relution\relution.cnf:/etc/mysql/conf.d/relution.cnf'
   mongodb:
     image: mongo:latest
     restart: always

--- a/docker/WindowsServer/Program Files/Relution/relution.cnf
+++ b/docker/WindowsServer/Program Files/Relution/relution.cnf
@@ -1,0 +1,10 @@
+[mysqld]
+collation-server=utf8mb4_general_ci
+character-set-server=utf8mb4
+max_allowed_packet=1G
+innodb_file_per_table=1
+
+## No longer needed/supported for MariaDB >= 10.2.2
+## If you have an older version please update or enable this
+# innodb_large_prefix=on
+# innodb_file_format=Barracuda


### PR DESCRIPTION
This adds the required database configuration to the docker-compose.yml
to ensure the database is set up correctly.