### PR TITLE
IOT-4626: configure systemd to use watchdog

### DIFF
--- a/native/Linux/etc/systemd/system/relution.service.template
+++ b/native/Linux/etc/systemd/system/relution.service.template
@@ -3,12 +3,16 @@ Description=Relution Server
 After=network.target
 
 [Service]
+Type=notify
+NotifyAccess=all
 TimeoutStartSec=0
+WatchdogSec=15min
 Environment=JAVA_HOME=/usr
-#ExecStartPre=/usr/bin/rm -rf /opt/relution/bundles-runtime
 ExecStart=/opt/relution/bin/relution-foreground.sh
 WorkingDirectory=/opt/relution
+KillMode=mixed
 KillSignal=SIGINT
+WatchdogSignal=SIGINT
 Restart=on-failure
 SyslogIdentifier=relution
 LimitNOFILE=10000


### PR DESCRIPTION
These changes are necessary for `systemd-notify` to work. It is used in `relution-watchdog.sh` which is started automatically by `relution-foreground.sh` when systemd with notify socket is detected. The changes cause systemd to delay returning from start requests until the web server is up and running and allow systemd to properly monitor the health endpoint so that sick instances will get restartet with incremental backoffs.