### PR TITLE
Change name of default network in docker compose

### DIFF
--- a/docker/Linux/opt/relution/compose.yaml
+++ b/docker/Linux/opt/relution/compose.yaml
@@ -57,4 +57,5 @@ volumes:
   postgresql:
 
 networks:
-  relution-network:
+  default:
+    name: "relution-network"


### PR DESCRIPTION
 instead of using a single implicit custom one